### PR TITLE
fixed typo causing missing ui description

### DIFF
--- a/modding-guides/vehicles/boe6s-guide-new-car-from-a-to-z/create-base-files.md
+++ b/modding-guides/vehicles/boe6s-guide-new-car-from-a-to-z/create-base-files.md
@@ -390,7 +390,7 @@ Vehicle.Mini:
     enumName: Mini_Logo
 
 Vehicle.boe6_mini_cooper_data:
-    $type: VehiculeUIData
+    $type: VehicleUIData
     productionYear: 2003
     info: LocKey#boe6_mini_cooper_info
 


### PR DESCRIPTION
in the summery at the end of the page there was a typo which caused the description to not show up properly