### PR TITLE
Update custom-advertisements-1.md

### DIFF
--- a/modding-guides/textures-and-luts/custom-advertisements-1.md
+++ b/modding-guides/textures-and-luts/custom-advertisements-1.md
@@ -7,7 +7,7 @@ description: How to make your own custom ads
 #### Summary
 
 **Published:** February 04 by [manavortex](https://app.gitbook.com/u/NfZBoxGegfUqB33J9HXuCs6PVaC3 "mention")\
-**Last documented edit:** February 04 by [manavortex](https://app.gitbook.com/u/NfZBoxGegfUqB33J9HXuCs6PVaC3 "mention")
+**Last documented edit:** March 28 by [nremind](https://next.nexusmods.com/profile/nremind)
 
 ### Other guides on this&#x20;
 
@@ -36,20 +36,179 @@ Use your image editor of choice (or [photopea](https://www.photopea.com/)) to ed
 When editing textures, please keep in mind that you need to export transparency as an alpha mask. See [images-importing-editing-exporting.md](../textures-and-luts/images-importing-editing-exporting.md "mention") for details.
 {% endhint %}
 
-After you are done editing, use the [Import Tool](https://app.gitbook.com/s/-MP\_ozZVx2gRZUPXkd4r/wolvenkit-app/tools/tools-import-export#import-tool) to import all the files.&#x20;
+## Step 2: Renaming and modifying files
 
-## Step 2: Delete those files you don't want
+{% hint style="info" %}
+Start here if you have already made a advertisement replacer, and want to convert your mod into a extension.
+{% endhint %}
+
+At this point, you might be tempted to just import the files to overwrite the vanilla game textures. Wait! With only a few more steps, rather than creating a replacer, you can create your own advertisement that can be added to the game that does not interfere with other mods.
+
+{% hint style="info" %}
+Q: Why not just make a replacer?
+A: Replacers all target the same file to overwrite, creating conflicts with other mods. If instead of replacers, mod authors took a few extra steps to make their own advertisements, there would be more total advertisements available to show in the game. Who wouldn't want that?
+{% endhint %}
+
+First, establish a new name for your ad. The convention is to use the name of the ad you are editing (e.g. broseph), followed by your mod author name (e.g. nremind), followed by a 2 digit number (e.g. 01) all lower-case and seperated by underscores. So in this example, the full name would be broseph_nremind_01. This is important for ease of integration between mods, and allowing users to easily know who created the mod. Use this to replace all instances of broseph in all files and file names. In the case of `.inkatlas` files, you'll notice that some files are called "broseph_atlas.inkatlas". Remember that you are replacing broseph, so the correct rename example for this file would be "broseph_nremind_01_atlas.inkatlas"
+
+Now that you know what to rename the files to, add the `.inkwidget` and `.inkatlas` files of the ad you wish to modify to your WolvenKit project. Right-click them and export to json. Open the json files in a text editor of your choice, and rename all instances of the ad name to your new ad name. For example, search and replace "broseph_atlas.inkatlas" to "broseph_nremind_01_atlas.inkatlas" in every instance in the file. Rename the png files with the same naming convention.
+
+{% hint style="info" %}
+It is not necessary to include your own `.inkanim` file. It's better to just link to the default one for the original ad, unless you are specifically making your own custom animation (moving the ad elements around differently, and changing the special animated effects). For more information on editing animations and widgets, refer to [this page](https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-creators-theory/files-and-what-they-do/file-formats/inkwidgets-a-custom-interface#inkanims-apply-animations-to-widgets-in-inkwidgets).
+{% endhint %}
+
+## Step 3: Adding your new mod to the game advertisement controller
+
+Now that you have created the new ad files, you need to tell the advertisement controller where it is. In this guide, we use TweakXL (by psiberx) to add the necessary records to TweakDB, the game's database.
+
+We will start with creating the records needed for your new ad. Use WolvenKit's Tweak Browser (on the far right-hand side of the window) and search for the name of the ad that you are modifying. Usually, you will want to choose the "animated" version if available for your particular ad (e.g. "Adverts.Broseph_Animated") so that it can be animated. Once you find it, right-click and "Add TweakXL Override", adding a .xl file to your project and giving you a starting point. Open the file and you will find a list of definitions that look familiar in the Tweak Browser in WolvenKit (e.g. Adverts.Broseph_01_4x3). These are `gamedataAdvertisementFormatDef_Record`. Find all of these definitions in WolvenKit's Tweak Browser, and do the same right-click -> "Add TweakXL Override" on each in the list. Add these to the `.xl` file under the main `gamedataAdvertisement_Record`. With your `.xl` file populated with the `gamedataAdvertisement_Record` and all of its associated `gamedataAdvertisementFormatDef_Record`, rename all of the ad names following the naming convention, EXCEPT for the `libraryName` in the `gamedataAdvertisementFormatDef_Record`s. The names of the file itself is not important except the file type of .xl at the end (these are actually yaml files read by TweakXL), but try to make the name obvious to users that these are related to your mod.
+
+Before:
+```
+Adverts.kangtao_Animated:
+  $type: gamedataAdvertisement_Record
+  resource: base\gameplay\gui\world\adverts\kangtao\kangtao_animated.inkwidget
+  definitions:
+    - Adverts.kangtao_4x3
+    - Adverts.kangtao_16x9
+    - Adverts.kangtao_3_3x1
+    - Adverts.kangtao_21x9
+
+Adverts.kangtao_4x3:
+  $type: gamedataAdvertisementFormatDef_Record
+  format: Format_4x3
+  libraryName: kangtao_4x3
+
+Adverts.kangtao_16x9:
+  $type: gamedataAdvertisementFormatDef_Record
+  format: Format_16x9
+  libraryName: kangtao_16x9
+
+Adverts.kangtao_3_3x1:
+  $type: gamedataAdvertisementFormatDef_Record
+  format: Format_3_3x1
+  libraryName: kangtao_3_3x1
+
+Adverts.kangtao_21x9:
+  $type: gamedataAdvertisementFormatDef_Record
+  format: Format_21x9
+  libraryName: kangtao_21x9
+```
+
+After:
+```
+Adverts.kangtao_nremind_01_Animated:
+  $type: gamedataAdvertisement_Record
+  resource: base\gameplay\gui\world\adverts\kangtao\kangtao_nremind_01_animated.inkwidget
+  definitions:
+    - Adverts.kangtao_nremind_01_4x3
+    - Adverts.kangtao_nremind_01_16x9
+    - Adverts.kangtao_nremind_01_3_3x1
+    - Adverts.kangtao_nremind_01_21x9
+
+Adverts.kangtao_nremind_01_4x3:
+  $type: gamedataAdvertisementFormatDef_Record
+  format: Format_4x3
+  libraryName: kangtao_4x3
+
+Adverts.kangtao_nremind_01_16x9:
+  $type: gamedataAdvertisementFormatDef_Record
+  format: Format_16x9
+  libraryName: kangtao_16x9
+
+Adverts.kangtao_nremind_01_3_3x1:
+  $type: gamedataAdvertisementFormatDef_Record
+  format: Format_3_3x1
+  libraryName: kangtao_3_3x1
+
+Adverts.kangtao_nremind_01_21x9:
+  $type: gamedataAdvertisementFormatDef_Record
+  format: Format_21x9
+  libraryName: kangtao_21x9
+```
+
+Next, we will add your newly created records to the districts where you want your ad to randomly appear in. Create a blank districts `.xl` file in the same folder as the previous file. Name it whatever you want. Add the following, replacing the ad name with the name of your ad:
+```
+Adverts.AllAdvertisements.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.ArasakaWF.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.BadLand.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.CharterHill.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.CityCenter.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.Glen.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.JapanTownCold.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.JapanTown.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.Kabuki.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.LittleChina.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.NorthIndustrial.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.NorthOak.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.PacificaCV_WWE.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.Rancho.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.SantoDomingo.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.VistaDelRay.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.WellSpring.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+
+Adverts.Spaceport.advertisements:
+  - !prepend Adverts.kangtao_nremind_01_Animated
+```
+
+This will add your ad to every district, but obviously you can choose not to include some districts where you don't want your ad to be shown. Now, the game knows about your records, and they are added to the game advert controller's district list.
+
+After you are done editing, use the [Import Tool](https://app.gitbook.com/s/-MP\_ozZVx2gRZUPXkd4r/wolvenkit-app/tools/tools-import-export#import-tool) to import all the files. Right-click and convert the `.inkatlas` and `.inkwidget` files from json.&#x20;
+
+## Step 4: Delete those files you don't want
 
 In your Wolvenkit project's [archive tab](https://app.gitbook.com/s/-MP\_ozZVx2gRZUPXkd4r/wolvenkit-app/editor/project-explorer#archive), delete those files that you don't want to include in your mod. This step is important, because files can only changed by one mod at a time, and you don't want to piss in the public water supply by simply leaving them in.
 
 When you have done the clean-up, you can now [install your mod](https://app.gitbook.com/s/-MP\_ozZVx2gRZUPXkd4r/wolvenkit-app/menu/toolbar#install-and-launch) and start the game to see your new ads in-game.
 
-## Step 3: Publishing
+## Step 5: Publishing
 
 If you want to post your mod on Nexus, you might want to do two things:
 
 * link back to this guide
 * Add [this mod](https://www.nexusmods.com/cyberpunk2077/mods/12790) as a requirement
 
-Happy modding, choom!
+## Step 6: Post-Publishing: Adding your mod for selection in a in-game menu.
 
+Once your mod has been published with its own Tweak records, it can be merged with everyone else's ads, making it available for toggling within a in-game menu with preview images. It supports automatic detection of advertisement extension mods, and can seamlessly integrate with your mod, displaying your ads if and only if your mod is installed. See [Advert Controller](https://www.nexusmods.com/cyberpunk2077/mods/18118).
+
+{% hint style="info" %}
+Disclaimer: The [author](https://www.nexusmods.com/users/24832504) of a large portion of this guide created this menu for advertisements.
+{% endhint %}
+
+DM this author if you would like to add your advertisement to this mod. There are no content limitations or restrictions on what will be integrated. This author will not gatekeep anything as long as you are not breaking asset permissions according to nexus rules.
+
+Happy modding, choom!


### PR DESCRIPTION
Add instructions on how to create advertisement extensions, not just advertisement replacers. This guide helps avoid mod conflicts, by showing a better way to prevent everyone from trying to overwrite the same texture file, hopefully leading to more total advertisements being added to the game that can be shown concurrently.

If you see any formatting mistakes or improvements, feel free to edit.