### PR TITLE
Add link to plugin file in MO2 plugin section

### DIFF
--- a/for-mod-users/users-modding-cyberpunk-2077/getting-started/mo2-mod-organizer-2.md
+++ b/for-mod-users/users-modding-cyberpunk-2077/getting-started/mo2-mod-organizer-2.md
@@ -85,7 +85,7 @@ I'm going to stress this as hard as I can: this plugin is not part of the main M
 
 <summary>Installing the plugin (must read!)</summary>
 
-1. Head over to the GitHub repository linked above and download the file `game_cyberpunk2077.py` by clicking on it, it's at the bottom of the page. **Do not download the source code.**
+1. Head over to the [GitHub repository](https://github.com/ModOrganizer2/modorganizer-basic_games/blob/master/games/game_cyberpunk2077.py) and download the file `game_cyberpunk2077.py` by clicking on the top-right three-dot menu, and clicking "Download."
 2. Place this file into `basic_games/games` which is located in the MO2 plugin folder. No need to go diving through all your folders to find it, you can find it easily:
    1.  Navigate to **Show Open Folders menu...** on the main MO2 screen.
 


### PR DESCRIPTION
Hi, I was following the section on installing the plugin to use CET/RED4ext/etc. via MO2 rather than manually. The section mentions "Head over to the GitHub repository linked above," but I couldn't find a link to that page.

This PR updates the MO2 readme to add a direct link to the plugin file instead.